### PR TITLE
bugfix “issues/2” - using smtp server with authentication always throws "wrong host name" error.

### DIFF
--- a/main.go
+++ b/main.go
@@ -176,7 +176,6 @@ func sendNotificationViaSmtp(notificatonUrl *url.URL, message string, verifyTls 
 	var auth = smtp.Auth(nil)
 	password, passSet := notificatonUrl.User.Password()
 	if passSet != false  {
-		//bugfix from original source - using Hostname instead of Host
 		auth = smtp.PlainAuth("", notificatonUrl.User.Username(), password, notificatonUrl.Hostname())
 	}
 

--- a/main.go
+++ b/main.go
@@ -176,7 +176,8 @@ func sendNotificationViaSmtp(notificatonUrl *url.URL, message string, verifyTls 
 	var auth = smtp.Auth(nil)
 	password, passSet := notificatonUrl.User.Password()
 	if passSet != false  {
-		auth = smtp.PlainAuth("", notificatonUrl.User.Username(), password, notificatonUrl.Host)
+		//bugfix from original source - using Hostname instead of Host
+		auth = smtp.PlainAuth("", notificatonUrl.User.Username(), password, notificatonUrl.Hostname())
 	}
 
 	smtpQueryString := notificatonUrl.Query()


### PR DESCRIPTION
ref: https://golang.org/pkg/net/smtp/#PlainAuth 